### PR TITLE
(widgets): Accept numpad Enter to confirm entry edits

### DIFF
--- a/src/widgets/card-widget.cpp
+++ b/src/widgets/card-widget.cpp
@@ -505,7 +505,8 @@ CardWidget::CardWidget(const std::string& title, Gdk::RGBA cover_color,
         [this](guint keyval, guint keycode, Gdk::ModifierType state) {
             if (m_card_entry_revealer.get_child_revealed()) {
                 switch (keyval) {
-                    case GDK_KEY_Return: {
+                    case GDK_KEY_Return:
+                    case GDK_KEY_KP_Enter: {
                         this->on_confirm_changes();
                         this->off_rename();
                         break;

--- a/src/widgets/editable-label-header.cpp
+++ b/src/widgets/editable-label-header.cpp
@@ -161,7 +161,8 @@ void EditableLabelHeader::on_key_released(guint keyval, guint keycode,
                                           Gdk::ModifierType state) {
     if (revealer.get_child_revealed()) {
         switch (keyval) {
-            case (GDK_KEY_Return): {
+            case (GDK_KEY_Return):
+            case (GDK_KEY_KP_Enter): {
                 on_confirm_changes();
                 break;
             }

--- a/src/widgets/task-widget.cpp
+++ b/src/widgets/task-widget.cpp
@@ -102,7 +102,8 @@ TaskWidget::TaskWidget(CardDialog& card_details_dialog, const std::string& name,
         [this](guint keyval, guint keycode, Gdk::ModifierType state) {
             if (m_entry_revealer.get_child_revealed()) {
                 switch (keyval) {
-                    case (GDK_KEY_Return): {
+                    case (GDK_KEY_Return):
+                    case (GDK_KEY_KP_Enter): {
                         off_rename();
                         break;
                     }


### PR DESCRIPTION
## Summary

The inline-edit Gtk::Entry widgets (card title, list header, task) only
handled GDK_KEY_Return, so users pressing Enter on the numpad (which
sends GDK_KEY_KP_Enter) had no effect. This adds the keypad variant to
the same case so both Enter keys confirm the edit.

## Changes
- src/widgets/editable-label-header.cpp
- src/widgets/task-widget.cpp
- src/widgets/card-widget.cpp

The modal dialogs (board-dialog, card-dialog) use Gtk::Entry's default
activate signal, which already handles both Enter keys, so they are
not affected.

## Testing
Built locally with cmake --build build (all 72 targets compile) and
ctest passes (5/5 existing tests).

## AI
Harness: OpenHands
Model: openrouter/minimax/minimax-m3:zdr